### PR TITLE
added package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "leaflet-indor-npm",
+  "version": "1.0.0",
+  "description": "Leaflet Indoor\r =====================",
+  "main": "leaflet-indoor.js",
+  "directories": {
+    "example": "examples"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/inakigarcia/leaflet-indoor.git"
+  },
+  "keywords": [
+    "indoor"
+  ],
+  "author": "Christopher Baines",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/inakigarcia/leaflet-indoor/issues"
+  },
+  "homepage": "https://github.com/inakigarcia/leaflet-indoor#readme"
+}


### PR DESCRIPTION
Hi

I was playing with browserify and leaflet packages in npm. Few days ago I used leaflet-indoor plugin and I tried to use it with npm.
finally I figured out that to use a repository from github like a npm package it need to hace a package.json file.
I did a fork wich just added a package.json file. If you think it can be helpful I'd like you to add it.

Thanks you a lot for your time.
Bests!
